### PR TITLE
chore: 라이브러리 최신화, readme수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Do you need another boilerplate?
 ## Specification
 
 - Localization
-- [Get package](https://pub.dev/packages/get) navigation settings
+- [Provider package](https://pub.dev/packages/provider)
 - Asset-related settings (Image, Icon, Color)
 - Testing settings
 

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ Do you need another boilerplate?
 # dependencies
 cupertino_icons: ^1.0.5
 intl: ^0.17.0
-get: ^4.6.5
+provider: ^6.0.4
 flutter_dotenv: ^5.0.2
 logger: ^1.1.0
-http: ^0.13.4
+http: ^0.13.5
 freezed_annotation: ^2.2.0
 json_annotation: ^4.7.0
 
 # dev_dependencies
 flutter_lints: ^2.0.1
 test: ^1.20.2
-mockito: ^5.2.0
-build_runner: ^2.3.0
-flutter_native_splash: ^2.2.5
+mockito: ^5.3.2
+build_runner: ^2.3.2
+flutter_native_splash: ^2.2.12
 change_app_package_name: ^1.1.0
 freezed: ^2.2.0
-json_serializable: ^6.5.2
+json_serializable: ^6.5.4
 ```
 
 ## Getting Started

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -253,7 +253,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.11"
+    version: "2.2.12"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -291,7 +291,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.1.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -317,7 +317,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: "direct main"
     description:
@@ -420,7 +420,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.5.2"
+    version: "6.5.4"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   provider: ^6.0.4
   flutter_dotenv: ^5.0.2
   logger: ^1.1.0
-  http: ^0.13.4
+  http: ^0.13.5
   freezed_annotation: ^2.2.0
   json_annotation: ^4.7.0
   image_picker: ^0.8.6
@@ -56,14 +56,14 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.1
   test: ^1.20.2
-  mockito: ^5.2.0
-  build_runner: ^2.3.0
-  flutter_native_splash: ^2.2.5
+  mockito: ^5.3.2
+  build_runner: ^2.3.2
+  flutter_native_splash: ^2.2.12
   # Rename App Package
   # flutter pub run change_app_package_name:main com.new.package.name
   change_app_package_name: ^1.1.0
   freezed: ^2.2.0
-  json_serializable: ^6.5.2
+  json_serializable: ^6.5.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
- getx > provider
- http 0.13.4 > 0.13.5
- mockito 5.2.0 > 5.3.2
- build_runner 2.3.0 > 2.3.2
- flutter_native_splash 2.2.5 > 2.2.12
- json_serializable 6.5.2 > 6.5.4